### PR TITLE
Sync main to master as an 'alias'

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,12 @@
+name: Sync Branches
+on:
+  push: { branches: main }
+  workflow_dispatch:
+
+jobs:
+  master:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - run: git push --force origin HEAD:refs/heads/master


### PR DESCRIPTION
About to rename the default branch to `main`. This will allow us to keep a `master` branch around as an 'alias' that is re-synced whenever `main` is pushed.